### PR TITLE
feat/anlatıcılar için puanlama haritası ekle

### DIFF
--- a/arka uç/uygulama/sabitler.py
+++ b/arka uç/uygulama/sabitler.py
@@ -1,0 +1,38 @@
+# Bu harita, farklı alimlerin kullandığı ifadeleri standart bir skora çevirir.
+# Puanlar 0.0 (tamamen güvenilmez) ile 1.0 (mükemmel güvenilir) arasındadır.
+# Bu değerler, akademik araştırmalara dayalı olarak daha da hassaslaştırılabilir.
+
+CERH_VE_TADIL_SKOR_HARITASI = {
+    # 1. Sınıf Ta'dil (En Güçlü Güvenilirlik)
+    "evsekunnas": 1.0,
+    "sika sika": 0.98,
+    "sika sikatun": 0.98,
+    "sika mutkin": 0.97,
+
+    # 2. Sınıf Ta'dil (Güçlü Güvenilirlik)
+    "sika": 0.95,
+    "hüccet": 0.92,
+    "adl": 0.90,
+
+    # 3. Sınıf Ta'dil (Orta Güvenilirlik - Hadisi Hasen seviyesinde)
+    "saduk": 0.85,
+    "leyse bihi be's": 0.80,
+    "mahaluhu's-sıdk": 0.75,
+
+    # 4. Sınıf (Kabul Edilebilir - Destekleyici rivayetlerle güçlenir)
+    "şeyh": 0.65,
+    "salihu'l-hadis": 0.60,
+    
+    # 5. Sınıf Cerh (Zayıflık)
+    "daif": 0.40,
+    "münkeru'l-hadis": 0.35,
+    "fihi makal": 0.30,
+    
+    # 6. Sınıf Cerh (Ciddi Zayıflık / İtham)
+    "metruk": 0.20,
+    "müttehemün bi'l-kizb": 0.10, # Yalancılıkla itham edilmiş
+    
+    # 7. Sınıf Cerh (En Ağır Suçlama)
+    "kezzab": 0.0,
+    "vadda'": 0.0, # Hadis uyduran
+}


### PR DESCRIPTION
#### **Özet (Summary)**

Bu Pull Request, Prof. Dr. Halis Aydemir'in "Hadis Rivayet Sistemine İhtimal Hesapları Merkezli Teorik bir Yaklaşım" makalesinde öne sürülen vizyonu hayata geçirmenin ilk adımıdır. Bu değişiklik, hadis alimlerinin râviler hakkında kullandığı sözel **"cerh ve ta'dil" ifadelerini**, sayısal (0.0 - 1.0) güvenilirlik skorlarına dönüştüren bir "harita" (sözlük) oluşturur.

#### **Yapılan Değişiklikler (Changes)**

*   `backend/app/constants.py` adında yeni bir modül oluşturuldu.
*   Bu modülün içine, `CERH_VE_TADIL_SKOR_HARITASI` adında bir Python sözlüğü (dictionary) eklendi.
*   Bu harita, "sika", "saduk", "daif", "kezzab" gibi standart hadis terminolojisini, râvi güvenilirliğini temsil eden sayısal bir değere eşler.

#### **Bu Değişikliğin Önemi (Motivation)**

Bu sabitler dosyası, projemizin en temel mantıksal parçasını oluşturur. Râvi skorlarını otomatik olarak hesaplayacak olan hizmet katmanımız (`services.py`), bu haritayı bir referans olarak kullanarak sübjektif sözel ifadeleri objektif ve hesaplanabilir verilere dönüştürecektir. Bu, projenin akademik temelini ve çekirdek işlevselliğini doğrudan destekler.

**Not:** Bu haritadaki sayısal değerler, ilk bir yaklaşım olarak belirlenmiştir ve gelecekte akademik araştırmalar ışığında daha da hassaslaştırılabilir.