### PR TITLE
başarı: Hadis sınıflandırmasını tetiklemek için API uç noktası oluşturma

### DIFF
--- a/arka uç/uygulama/main.py
+++ b/arka uç/uygulama/main.py
@@ -16,3 +16,16 @@ def hesapla_ravi_skor_endpoint(ravi_id: int, db: Session = Depends(get_db)):
     # db.commit()
     
     return hesaplanan_skorlar
+# backend/app/main.py dosyasının sonuna ekleyin
+
+@app.post("/hadisler/{hadis_id}/classify", response_model=schemas.SiniflandirmaSonuc)
+def classify_hadith_endpoint(hadis_id: int, db: Session = Depends(get_db)):
+    """
+    Bir hadisin sıhhat durumunu, isnadındaki râvilerin güvenilirlik
+    skorlarına dayanarak otomatik olarak sınıflandırır.
+    """
+    sonuc = services.siniflandir_hadis(db, hadis_id=hadis_id)
+    if "hata" in sonuc:
+        raise HTTPException(status_code=404, detail=sonuc["hata"])
+    
+    return sonuc


### PR DESCRIPTION
#### Özet
Bu Pull Request, projenin çekirdek iş mantığını bir HTTP endpoint'i aracılığıyla dış dünyaya açar. `main.py` dosyasına eklenen yeni `POST /hadisler/{hadis_id}/classify` rotası, `services.py`'deki `siniflandir_hadis` fonksiyonunu tetikler ve hesaplanan sonucu istemciye döndürür.

#### Yapılan Değişiklikler
- `main.py`'e `classify_hadith_endpoint` adında yeni bir fonksiyon eklendi.
- Endpoint, `services.siniflandir_hadis` fonksiyonunu çağırır.
- Fonksiyondan bir hata dönerse (örn: hadis bulunamazsa), uygun bir `HTTPException` (404) fırlatır.
- Başarılı bir sonuç döndüğünde, bu sonucu daha önce tanımlanan `schemas.SiniflandirmaSonuc` şemasına uygun olarak döndürür.

#### Nasıl Test Edilir?
`/docs` adresindeki Swagger arayüzü kullanılarak, bir `hadis_id` ile bu endpoint'e bir `POST` isteği gönderilerek test edilebilir.