### PR TITLE
başarı: JWT doğrulaması için güvenlik modülü oluşturma

### DIFF
--- a/arka uç/uygulama/güvenlik.py
+++ b/arka uç/uygulama/güvenlik.py
@@ -1,0 +1,37 @@
+# backend/app/security.py
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+import os
+from . import crud # Kullanıcıyı veritabanından bulmak için (isteğe bağlı)
+from .database import SessionLocal
+
+# Supabase'den gelen JWT'yi doğrulamak için gerekli bilgiler
+# .env dosyasından okuyoruz
+SECRET_KEY = os.getenv("SUPABASE_JWT_SECRET")
+ALGORITHM = "HS256"
+
+# Bu, FastAPI'ye token'ın "Authorization: Bearer <token>" başlığından
+# geleceğini söyleyen bir yardımcıdır.
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+def get_current_user_id(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        # Gelen token'ı, gizli anahtarımızla çözmeyi deniyoruz
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        
+        # Supabase JWT'sinin içindeki kullanıcı ID'si 'sub' alanında bulunur
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    
+    # Token geçerliyse, içindeki kullanıcı ID'sini döndürüyoruz
+    return user_id


### PR DESCRIPTION
#### **Özet (Summary)**

Bu Pull Request, backend API'sine bir kimlik doğrulama (authentication) ve yetkilendirme (authorization) altyapısı ekler. `security.py` adında yeni bir modül oluşturularak, Supabase'den gelen JWT'leri (JSON Web Tokens) doğrulamak için yeniden kullanılabilir bir mantık geliştirilmiştir. Bu, API endpoint'lerini koruma altına almanın ve isteklerin kimliği doğrulanmış kullanıcılardan geldiğinden emin olmanın temelini atar.

#### **Yapılan Değişiklikler (Changes)**

1.  **Bağımlılıklar Eklendi:** `python-jose[cryptography]` kütüphanesi, JWT işleme yetenekleri için `requirements.txt`'e eklendi.
2.  **Yeni Güvenlik Modülü Oluşturuldu (`security.py`):**
    *   Bu modül, `.env` dosyasından okunan `SUPABASE_JWT_SECRET`'ı kullanarak token'ları doğrulamak için gerekli yapılandırmayı içerir.
    *   `get_current_user_id` adında bir FastAPI **bağımlılığı (dependency)** oluşturuldu. Bu fonksiyon, `Authorization: Bearer <token>` başlığından gelen token'ı alır, geçerliliğini kontrol eder ve token geçerliyse içindeki kullanıcı ID'sini (`sub` alanı) döndürür.
    *   Token geçersiz veya eksikse, istemciye standart bir `401 Unauthorized` HTTP hatası döndürür.

#### **Bu Mimarinin Önemi (Architectural Significance)**

Bu merkezi güvenlik modülü, endpoint'leri koruma işlemini son derece basit hale getirir. Artık bir endpoint'i korumak için, o endpoint'in tanımına bu `get_current_user_id` bağımlılığını enjekte etmek yeterlidir. Bu, güvenlik mantığını kodun her yerine kopyalayıp yapıştırmayı önler (DRY prensibi) ve gelecekte güvenlik kurallarını tek bir yerden güncellemeyi kolaylaştırır.